### PR TITLE
Fix/readme eslint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ npx install-peerdeps --dev @cleverage/eslint-config
 
 ```json
 {
-  "extends": "cleverage"
+  "extends": "@cleverage/eslint-config"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleverage/eslint-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "eslint config for Clever Age projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
With `'cleverage'` eslint try to resolve the node module named `eslint-config-cleverage`
```
Error: Cannot find module 'eslint-config-cleverage'
Referenced from: …/.eslintrc.js
    at ModuleResolver.resolve (…/node_modules/eslint/lib/util/module-resolver.js:72:19)
    at resolve (…/node_modules/eslint/lib/config/config-file.js:484:28)
    at load (…/node_modules/eslint/lib/config/config-file.js:556:26)
    at configExtends.reduceRight (…/node_modules/eslint/lib/config/config-file.js:430:36)
    at Array.reduceRight (<anonymous>)
    at applyExtends (…/node_modules/eslint/lib/config/config-file.js:408:26)
    at loadFromDisk (…/node_modules/eslint/lib/config/config-file.js:528:22)
    at Object.load (…/node_modules/eslint/lib/config/config-file.js:564:20)
    at Config.getLocalConfigHierarchy (…/node_modules/eslint/lib/config.js:240:44)
    at Config.getConfigHierarchy (…/node_modules/eslint/lib/config.js:192:43)
```

To fix it we have to use complete module name